### PR TITLE
[Fix] 페이지 숫자 보여주는 기능 수정

### DIFF
--- a/src/views/examples/analysis/FullAnal.css
+++ b/src/views/examples/analysis/FullAnal.css
@@ -201,3 +201,17 @@
   color: #060606;
   border: 2px solid #5a96f6;
 }
+
+.pageNumber {
+    /* 기본 페이지 번호 스타일 */
+    transition: color 0.3s ease;
+}
+
+.pageNumber:hover {
+    color: #007bff; /* 호버 시 색상 변경 */
+}
+
+.active {
+    font-weight: bold;
+    color: #dc3545; /* 현재 페이지 번호 색상 */
+}

--- a/src/views/examples/analysis/FullAnal.js
+++ b/src/views/examples/analysis/FullAnal.js
@@ -3,12 +3,11 @@ import "./FullAnal.css";
 
 function FullAnal() {
     const [data, setData] = useState([]);
-    const [startIndex, setStartIndex] = useState(0);
+    const [currentPage, setCurrentPage] = useState(1);
     const [totalPages, setTotalPages] = useState(0);
-    const itemsPerPage = 10; // 페이지 당 항목 수
+    const itemsPerPage = 10;
 
     useEffect(() => {
-        // 데이터가 업데이트될 때마다 총 페이지 수를 다시 계산
         setTotalPages(Math.ceil(data.length / itemsPerPage));
     }, [data]);
 
@@ -117,6 +116,1016 @@ function FullAnal() {
                         admissionProbability: "67",
                         category: "적절",
                     },
+                    {
+                        school: "전북대학교",
+                        major: "경제학과",
+                        admissionProbability: "84",
+                        category: "적절",
+                    },
+                    /*
+                    {
+                        school: "아주대학교",
+                        major: "국제학과",
+                        admissionProbability: "71",
+                        category: "적절",
+                    },
+                    {
+                        school: "한밭대학교",
+                        major: "의학과",
+                        admissionProbability: "75",
+                        category: "적절",
+                    },
+                    {
+                        school: "충북대학교",
+                        major: "사회학과",
+                        admissionProbability: "78",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "경영학과",
+                        admissionProbability: "82",
+                        category: "적절",
+                    },
+                    {
+                        school: "경남대학교",
+                        major: "교육학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "안동대학교",
+                        major: "예술학과",
+                        admissionProbability: "74",
+                        category: "적절",
+                    },
+                    {
+                        school: "경기대학교",
+                        major: "신소재공학과",
+                        admissionProbability: "76",
+                        category: "적절",
+                    },
+                    {
+                        school: "가천대학교",
+                        major: "화학공학과",
+                        admissionProbability: "70",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "컴퓨터공학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "경상대학교",
+                        major: "철학과",
+                        admissionProbability: "83",
+                        category: "적절",
+                    },
+                    {
+                        school: "전남대학교",
+                        major: "패션의류학과",
+                        admissionProbability: "67",
+                        category: "적절",
+                    },
+                    {
+                        school: "전북대학교",
+                        major: "경제학과",
+                        admissionProbability: "84",
+                        category: "적절",
+                    },
+                    {
+                        school: "아주대학교",
+                        major: "국제학과",
+                        admissionProbability: "71",
+                        category: "적절",
+                    },
+                    {
+                        school: "한밭대학교",
+                        major: "의학과",
+                        admissionProbability: "75",
+                        category: "적절",
+                    },
+                    {
+                        school: "충북대학교",
+                        major: "사회학과",
+                        admissionProbability: "78",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "경영학과",
+                        admissionProbability: "82",
+                        category: "적절",
+                    },
+                    {
+                        school: "경남대학교",
+                        major: "교육학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "안동대학교",
+                        major: "예술학과",
+                        admissionProbability: "74",
+                        category: "적절",
+                    },
+                    {
+                        school: "경기대학교",
+                        major: "신소재공학과",
+                        admissionProbability: "76",
+                        category: "적절",
+                    },
+                    {
+                        school: "가천대학교",
+                        major: "화학공학과",
+                        admissionProbability: "70",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "컴퓨터공학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "경상대학교",
+                        major: "철학과",
+                        admissionProbability: "83",
+                        category: "적절",
+                    },
+                    {
+                        school: "전남대학교",
+                        major: "패션의류학과",
+                        admissionProbability: "67",
+                        category: "적절",
+                    },
+                    {
+                        school: "전북대학교",
+                        major: "경제학과",
+                        admissionProbability: "84",
+                        category: "적절",
+                    },
+                    {
+                        school: "아주대학교",
+                        major: "국제학과",
+                        admissionProbability: "71",
+                        category: "적절",
+                    },
+                    {
+                        school: "한밭대학교",
+                        major: "의학과",
+                        admissionProbability: "75",
+                        category: "적절",
+                    },
+                    {
+                        school: "충북대학교",
+                        major: "사회학과",
+                        admissionProbability: "78",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "경영학과",
+                        admissionProbability: "82",
+                        category: "적절",
+                    },
+                    {
+                        school: "경남대학교",
+                        major: "교육학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "안동대학교",
+                        major: "예술학과",
+                        admissionProbability: "74",
+                        category: "적절",
+                    },
+                    {
+                        school: "경기대학교",
+                        major: "신소재공학과",
+                        admissionProbability: "76",
+                        category: "적절",
+                    },
+                    {
+                        school: "가천대학교",
+                        major: "화학공학과",
+                        admissionProbability: "70",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "컴퓨터공학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "경상대학교",
+                        major: "철학과",
+                        admissionProbability: "83",
+                        category: "적절",
+                    },
+                    {
+                        school: "전남대학교",
+                        major: "패션의류학과",
+                        admissionProbability: "67",
+                        category: "적절",
+                    },
+                    {
+                        school: "전북대학교",
+                        major: "경제학과",
+                        admissionProbability: "84",
+                        category: "적절",
+                    },
+                    {
+                        school: "아주대학교",
+                        major: "국제학과",
+                        admissionProbability: "71",
+                        category: "적절",
+                    },
+                    {
+                        school: "한밭대학교",
+                        major: "의학과",
+                        admissionProbability: "75",
+                        category: "적절",
+                    },
+                    {
+                        school: "충북대학교",
+                        major: "사회학과",
+                        admissionProbability: "78",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "경영학과",
+                        admissionProbability: "82",
+                        category: "적절",
+                    },
+                    {
+                        school: "경남대학교",
+                        major: "교육학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "안동대학교",
+                        major: "예술학과",
+                        admissionProbability: "74",
+                        category: "적절",
+                    },
+                    {
+                        school: "경기대학교",
+                        major: "신소재공학과",
+                        admissionProbability: "76",
+                        category: "적절",
+                    },
+                    {
+                        school: "가천대학교",
+                        major: "화학공학과",
+                        admissionProbability: "70",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "컴퓨터공학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "경상대학교",
+                        major: "철학과",
+                        admissionProbability: "83",
+                        category: "적절",
+                    },
+                    {
+                        school: "전남대학교",
+                        major: "패션의류학과",
+                        admissionProbability: "67",
+                        category: "적절",
+                    },
+                    {
+                        school: "전북대학교",
+                        major: "경제학과",
+                        admissionProbability: "84",
+                        category: "적절",
+                    },
+                    {
+                        school: "아주대학교",
+                        major: "국제학과",
+                        admissionProbability: "71",
+                        category: "적절",
+                    },
+                    {
+                        school: "한밭대학교",
+                        major: "의학과",
+                        admissionProbability: "75",
+                        category: "적절",
+                    },
+                    {
+                        school: "충북대학교",
+                        major: "사회학과",
+                        admissionProbability: "78",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "경영학과",
+                        admissionProbability: "82",
+                        category: "적절",
+                    },
+                    {
+                        school: "경남대학교",
+                        major: "교육학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "안동대학교",
+                        major: "예술학과",
+                        admissionProbability: "74",
+                        category: "적절",
+                    },
+                    {
+                        school: "경기대학교",
+                        major: "신소재공학과",
+                        admissionProbability: "76",
+                        category: "적절",
+                    },
+                    {
+                        school: "가천대학교",
+                        major: "화학공학과",
+                        admissionProbability: "70",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "컴퓨터공학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "경상대학교",
+                        major: "철학과",
+                        admissionProbability: "83",
+                        category: "적절",
+                    },
+                    {
+                        school: "전남대학교",
+                        major: "패션의류학과",
+                        admissionProbability: "67",
+                        category: "적절",
+                    },
+                    {
+                        school: "전북대학교",
+                        major: "경제학과",
+                        admissionProbability: "84",
+                        category: "적절",
+                    },
+                    {
+                        school: "아주대학교",
+                        major: "국제학과",
+                        admissionProbability: "71",
+                        category: "적절",
+                    },
+                    {
+                        school: "한밭대학교",
+                        major: "의학과",
+                        admissionProbability: "75",
+                        category: "적절",
+                    },
+                    {
+                        school: "충북대학교",
+                        major: "사회학과",
+                        admissionProbability: "78",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "경영학과",
+                        admissionProbability: "82",
+                        category: "적절",
+                    },
+                    {
+                        school: "경남대학교",
+                        major: "교육학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "안동대학교",
+                        major: "예술학과",
+                        admissionProbability: "74",
+                        category: "적절",
+                    },
+                    {
+                        school: "경기대학교",
+                        major: "신소재공학과",
+                        admissionProbability: "76",
+                        category: "적절",
+                    },
+                    {
+                        school: "가천대학교",
+                        major: "화학공학과",
+                        admissionProbability: "70",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "컴퓨터공학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "경상대학교",
+                        major: "철학과",
+                        admissionProbability: "83",
+                        category: "적절",
+                    },
+                    {
+                        school: "전남대학교",
+                        major: "패션의류학과",
+                        admissionProbability: "67",
+                        category: "적절",
+                    },
+                    {
+                        school: "전북대학교",
+                        major: "경제학과",
+                        admissionProbability: "84",
+                        category: "적절",
+                    },
+                    {
+                        school: "아주대학교",
+                        major: "국제학과",
+                        admissionProbability: "71",
+                        category: "적절",
+                    },
+                    {
+                        school: "한밭대학교",
+                        major: "의학과",
+                        admissionProbability: "75",
+                        category: "적절",
+                    },
+                    {
+                        school: "충북대학교",
+                        major: "사회학과",
+                        admissionProbability: "78",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "경영학과",
+                        admissionProbability: "82",
+                        category: "적절",
+                    },
+                    {
+                        school: "경남대학교",
+                        major: "교육학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "안동대학교",
+                        major: "예술학과",
+                        admissionProbability: "74",
+                        category: "적절",
+                    },
+                    {
+                        school: "경기대학교",
+                        major: "신소재공학과",
+                        admissionProbability: "76",
+                        category: "적절",
+                    },
+                    {
+                        school: "가천대학교",
+                        major: "화학공학과",
+                        admissionProbability: "70",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "컴퓨터공학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "경상대학교",
+                        major: "철학과",
+                        admissionProbability: "83",
+                        category: "적절",
+                    },
+                    {
+                        school: "전남대학교",
+                        major: "패션의류학과",
+                        admissionProbability: "67",
+                        category: "적절",
+                    },
+                    {
+                        school: "전북대학교",
+                        major: "경제학과",
+                        admissionProbability: "84",
+                        category: "적절",
+                    },
+                    {
+                        school: "아주대학교",
+                        major: "국제학과",
+                        admissionProbability: "71",
+                        category: "적절",
+                    },
+                    {
+                        school: "한밭대학교",
+                        major: "의학과",
+                        admissionProbability: "75",
+                        category: "적절",
+                    },
+                    {
+                        school: "충북대학교",
+                        major: "사회학과",
+                        admissionProbability: "78",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "경영학과",
+                        admissionProbability: "82",
+                        category: "적절",
+                    },
+                    {
+                        school: "경남대학교",
+                        major: "교육학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "안동대학교",
+                        major: "예술학과",
+                        admissionProbability: "74",
+                        category: "적절",
+                    },
+                    {
+                        school: "경기대학교",
+                        major: "신소재공학과",
+                        admissionProbability: "76",
+                        category: "적절",
+                    },
+                    {
+                        school: "가천대학교",
+                        major: "화학공학과",
+                        admissionProbability: "70",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "컴퓨터공학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "경상대학교",
+                        major: "철학과",
+                        admissionProbability: "83",
+                        category: "적절",
+                    },
+                    {
+                        school: "전남대학교",
+                        major: "패션의류학과",
+                        admissionProbability: "67",
+                        category: "적절",
+                    },
+                    {
+                        school: "전북대학교",
+                        major: "경제학과",
+                        admissionProbability: "84",
+                        category: "적절",
+                    },
+                    {
+                        school: "아주대학교",
+                        major: "국제학과",
+                        admissionProbability: "71",
+                        category: "적절",
+                    },
+                    {
+                        school: "한밭대학교",
+                        major: "의학과",
+                        admissionProbability: "75",
+                        category: "적절",
+                    },
+                    {
+                        school: "충북대학교",
+                        major: "사회학과",
+                        admissionProbability: "78",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "경영학과",
+                        admissionProbability: "82",
+                        category: "적절",
+                    },
+                    {
+                        school: "경남대학교",
+                        major: "교육학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "안동대학교",
+                        major: "예술학과",
+                        admissionProbability: "74",
+                        category: "적절",
+                    },
+                    {
+                        school: "경기대학교",
+                        major: "신소재공학과",
+                        admissionProbability: "76",
+                        category: "적절",
+                    },
+                    {
+                        school: "가천대학교",
+                        major: "화학공학과",
+                        admissionProbability: "70",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "컴퓨터공학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "경상대학교",
+                        major: "철학과",
+                        admissionProbability: "83",
+                        category: "적절",
+                    },
+                    {
+                        school: "전남대학교",
+                        major: "패션의류학과",
+                        admissionProbability: "67",
+                        category: "적절",
+                    },
+                    {
+                        school: "전북대학교",
+                        major: "경제학과",
+                        admissionProbability: "84",
+                        category: "적절",
+                    },
+                    {
+                        school: "아주대학교",
+                        major: "국제학과",
+                        admissionProbability: "71",
+                        category: "적절",
+                    },
+                    {
+                        school: "한밭대학교",
+                        major: "의학과",
+                        admissionProbability: "75",
+                        category: "적절",
+                    },
+                    {
+                        school: "충북대학교",
+                        major: "사회학과",
+                        admissionProbability: "78",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "경영학과",
+                        admissionProbability: "82",
+                        category: "적절",
+                    },
+                    {
+                        school: "경남대학교",
+                        major: "교육학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "안동대학교",
+                        major: "예술학과",
+                        admissionProbability: "74",
+                        category: "적절",
+                    },
+                    {
+                        school: "경기대학교",
+                        major: "신소재공학과",
+                        admissionProbability: "76",
+                        category: "적절",
+                    },
+                    {
+                        school: "가천대학교",
+                        major: "화학공학과",
+                        admissionProbability: "70",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "컴퓨터공학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "경상대학교",
+                        major: "철학과",
+                        admissionProbability: "83",
+                        category: "적절",
+                    },
+                    {
+                        school: "전남대학교",
+                        major: "패션의류학과",
+                        admissionProbability: "67",
+                        category: "적절",
+                    },
+                    {
+                        school: "전북대학교",
+                        major: "경제학과",
+                        admissionProbability: "84",
+                        category: "적절",
+                    },
+                    {
+                        school: "아주대학교",
+                        major: "국제학과",
+                        admissionProbability: "71",
+                        category: "적절",
+                    },
+                    {
+                        school: "한밭대학교",
+                        major: "의학과",
+                        admissionProbability: "75",
+                        category: "적절",
+                    },
+                    {
+                        school: "충북대학교",
+                        major: "사회학과",
+                        admissionProbability: "78",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "경영학과",
+                        admissionProbability: "82",
+                        category: "적절",
+                    },
+                    {
+                        school: "경남대학교",
+                        major: "교육학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "안동대학교",
+                        major: "예술학과",
+                        admissionProbability: "74",
+                        category: "적절",
+                    },
+                    {
+                        school: "경기대학교",
+                        major: "신소재공학과",
+                        admissionProbability: "76",
+                        category: "적절",
+                    },
+                    {
+                        school: "가천대학교",
+                        major: "화학공학과",
+                        admissionProbability: "70",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "컴퓨터공학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "경상대학교",
+                        major: "철학과",
+                        admissionProbability: "83",
+                        category: "적절",
+                    },
+                    {
+                        school: "전남대학교",
+                        major: "패션의류학과",
+                        admissionProbability: "67",
+                        category: "적절",
+                    },
+                    {
+                        school: "전북대학교",
+                        major: "경제학과",
+                        admissionProbability: "84",
+                        category: "적절",
+                    },
+                    {
+                        school: "아주대학교",
+                        major: "국제학과",
+                        admissionProbability: "71",
+                        category: "적절",
+                    },
+                    {
+                        school: "한밭대학교",
+                        major: "의학과",
+                        admissionProbability: "75",
+                        category: "적절",
+                    },
+                    {
+                        school: "충북대학교",
+                        major: "사회학과",
+                        admissionProbability: "78",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "경영학과",
+                        admissionProbability: "82",
+                        category: "적절",
+                    },
+                    {
+                        school: "경남대학교",
+                        major: "교육학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "안동대학교",
+                        major: "예술학과",
+                        admissionProbability: "74",
+                        category: "적절",
+                    },
+                    {
+                        school: "경기대학교",
+                        major: "신소재공학과",
+                        admissionProbability: "76",
+                        category: "적절",
+                    },
+                    {
+                        school: "가천대학교",
+                        major: "화학공학과",
+                        admissionProbability: "70",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "컴퓨터공학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "경상대학교",
+                        major: "철학과",
+                        admissionProbability: "83",
+                        category: "적절",
+                    },
+                    {
+                        school: "전남대학교",
+                        major: "패션의류학과",
+                        admissionProbability: "67",
+                        category: "적절",
+                    },
+                    {
+                        school: "전북대학교",
+                        major: "경제학과",
+                        admissionProbability: "84",
+                        category: "적절",
+                    },
+                    {
+                        school: "아주대학교",
+                        major: "국제학과",
+                        admissionProbability: "71",
+                        category: "적절",
+                    },
+                    {
+                        school: "한밭대학교",
+                        major: "의학과",
+                        admissionProbability: "75",
+                        category: "적절",
+                    },
+                    {
+                        school: "충북대학교",
+                        major: "사회학과",
+                        admissionProbability: "78",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "경영학과",
+                        admissionProbability: "82",
+                        category: "적절",
+                    },
+                    {
+                        school: "경남대학교",
+                        major: "교육학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "안동대학교",
+                        major: "예술학과",
+                        admissionProbability: "74",
+                        category: "적절",
+                    },
+                    {
+                        school: "경기대학교",
+                        major: "신소재공학과",
+                        admissionProbability: "76",
+                        category: "적절",
+                    },
+                    {
+                        school: "가천대학교",
+                        major: "화학공학과",
+                        admissionProbability: "70",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "컴퓨터공학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "경상대학교",
+                        major: "철학과",
+                        admissionProbability: "83",
+                        category: "적절",
+                    },
+                    {
+                        school: "전남대학교",
+                        major: "패션의류학과",
+                        admissionProbability: "67",
+                        category: "적절",
+                    },
+                    {
+                        school: "전북대학교",
+                        major: "경제학과",
+                        admissionProbability: "84",
+                        category: "적절",
+                    },
+                    {
+                        school: "아주대학교",
+                        major: "국제학과",
+                        admissionProbability: "71",
+                        category: "적절",
+                    },
+                    {
+                        school: "한밭대학교",
+                        major: "의학과",
+                        admissionProbability: "75",
+                        category: "적절",
+                    },
+                    {
+                        school: "충북대학교",
+                        major: "사회학과",
+                        admissionProbability: "78",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "경영학과",
+                        admissionProbability: "82",
+                        category: "적절",
+                    },
+                    {
+                        school: "경남대학교",
+                        major: "교육학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "안동대학교",
+                        major: "예술학과",
+                        admissionProbability: "74",
+                        category: "적절",
+                    },
+                    {
+                        school: "경기대학교",
+                        major: "신소재공학과",
+                        admissionProbability: "76",
+                        category: "적절",
+                    },
+                    {
+                        school: "가천대학교",
+                        major: "화학공학과",
+                        admissionProbability: "70",
+                        category: "적절",
+                    },
+                    {
+                        school: "경북대학교",
+                        major: "컴퓨터공학과",
+                        admissionProbability: "79",
+                        category: "적절",
+                    },
+                    {
+                        school: "경상대학교",
+                        major: "철학과",
+                        admissionProbability: "83",
+                        category: "적절",
+                    },
+                    {
+                        school: "전남대학교",
+                        major: "패션의류학과",
+                        admissionProbability: "67",
+                        category: "적절",
+                    },
+
                 ];
                 break;
             case "도전":
@@ -151,6 +1160,7 @@ function FullAnal() {
                         admissionProbability: "52",
                         category: "도전",
                     },
+                    */
                 ];
                 break;
             case "위험":
@@ -211,18 +1221,56 @@ function FullAnal() {
         // 합격률에 따라 내림차순 정렬
         newData.sort((a, b) => b.admissionProbability - a.admissionProbability);
         setData(newData);
-        setStartIndex(0); // 데이터가 변경될 때 시작 인덱스를 0으로 초기화
+        setCurrentPage(1); // 데이터가 변경될 때마다 첫 페이지로 초기화
+    };
+
+    const handlePageClick = (pageNumber) => {
+        setCurrentPage(pageNumber);
     };
 
     const handlePreviousButtonClick = () => {
-        setStartIndex(Math.max(0, startIndex - 10)); // 이전 버튼 클릭 시 시작 인덱스 변경
+        setCurrentPage(currentPage > 1 ? currentPage - 1 : 1);
     };
 
     const handleNextButtonClick = () => {
-        if (startIndex + 10 < data.length) {
-            setStartIndex(startIndex + 10); // 다음 버튼 클릭 시 시작 인덱스 변경
-        }
+        setCurrentPage(currentPage < totalPages ? currentPage + 1 : totalPages);
     };
+
+    const renderPageNumbers = () => {
+        let startPage, endPage;
+        if (totalPages <= 10) {
+            // 전체 페이지가 10개 이하인 경우
+            startPage = 1;
+            endPage = totalPages;
+        } else {
+            // 현재 페이지가 5 이상인 경우, 앞으로 5개, 뒤로 5개의 페이지 번호를 표시
+            if (currentPage <= 5) {
+                startPage = 1;
+                endPage = 10;
+            } else if (currentPage + 4 >= totalPages) {
+                startPage = totalPages - 9;
+                endPage = totalPages;
+            } else {
+                startPage = currentPage - 5;
+                endPage = currentPage + 5;
+            }
+        }
+    
+        return (
+            <div className="pageNumbers">
+                {Array.from({ length: (endPage + 1) - startPage }, (_, i) => startPage + i).map(number => (
+                    <span key={number} 
+                        className={`pageNumber ${currentPage === number ? 'active' : ''}`}
+                        onClick={() => handlePageClick(number)}
+                        style={{ cursor: 'pointer', margin: '0 10px' }}>
+                        {number}
+                    </span>
+                ))}
+            </div>
+        );
+    };
+    
+    const startIndex = (currentPage - 1) * itemsPerPage;
 
     const getColorClass = (category) => {
         switch (category) {
@@ -270,7 +1318,7 @@ function FullAnal() {
             </div>
             <div className="contentBelow">
                 <div className="fourColumns">
-                    {data.slice(startIndex, startIndex + 10).map((item, index) => (
+                    {data.slice(startIndex, startIndex + itemsPerPage).map((item, index) => (
                         <div className="column" key={index}>
                             <div className={`box ${getColorClass(item.category)}`}>{item.school}</div>
                             <div className={`box ${getColorClass(item.category)}`}>{item.major}</div>
@@ -284,18 +1332,17 @@ function FullAnal() {
                     ))}
                 </div>
             </div>
+
             {/* 이전 버튼과 다음 버튼 사이에 페이지 수 표시 */}
             <div className="pagination">
-                <button className="previousButton" onClick={handlePreviousButtonClick}>
+                <button className="previousButton" onClick={handlePreviousButtonClick} disabled={currentPage === 1}>
                     &lt;
                 </button>
-                {/* 현재 페이지 번호와 총 페이지 수를 표시 */}
-                <span className="pageInfo">{`${startIndex / itemsPerPage + 1}/${totalPages}`}</span>
-                <button className="nextButton" onClick={handleNextButtonClick}>
+                {renderPageNumbers()}
+                <button className="nextButton" onClick={handleNextButtonClick} disabled={currentPage === totalPages}>
                     &gt;
                 </button>
             </div>
-
         </div>
     );
 }


### PR DESCRIPTION
- 페이지 숫자 보여주는 방식을 1 2 3 4 5 6 7 8 9 10과 같이 보이게 함.
- 페이지 이동 방식 구현 (한 화면에 숫자 10개만 보이도록 함, 데이터가 10페이지 이상일 경우 페이지 숫자가 특정 값을 넘어가면 자동으로 10페이지 이후의 페이지 숫자가 보이도록 함)
- 현재 페이지의 숫자가 눈에 잘 띄도록 빨간색으로 수정
- 이전 버튼과 다음 버튼 누르면 자연스럽게 페이지 이동 가능하게 함.